### PR TITLE
Improve naming in RedditClient class.

### DIFF
--- a/src/services/RedditClient.ts
+++ b/src/services/RedditClient.ts
@@ -238,7 +238,7 @@ class RedditClient {
     }
   }
 
-  public async getBest(limit: number = 25, depth: number = 10, afterParam?: string | null): Promise<IListingNewChildren[]> {
+  public async getBestPosts(limit: number = 25, depth: number = 10, afterParam?: string | null): Promise<IListingNewChildren[]> {
     if (!this.accessToken) {
       throw Error("Unable to make request. Authentication has not been established");
     }

--- a/tests/e2e/index.test.ts
+++ b/tests/e2e/index.test.ts
@@ -47,7 +47,7 @@ describe("testing E2E RedditClient. This calls the Reddit API", () => {
     };
     const myRedditClient = new RedditClient(config);
     await myRedditClient.auth({ username: `${process.env.USERNAME}`, password: `${process.env.PASSWORD}` });
-    const posts: IListingNewChildren[] = await myRedditClient.getBest(2, 2);
+    const posts: IListingNewChildren[] = await myRedditClient.getBestPosts(2, 2);
     posts.forEach((post) => {
       console.log(post.data.title);
       //console.log(new Date(post.data.created * 1000));


### PR DESCRIPTION
This PR makes the naming of the functions in RedditClient class more consistent, by changing the name of the function getBest to getBestPosts. It also fixes the bug of calling getBestPosts in the usage example.
All tests are passing.